### PR TITLE
Fix two crashes on fresh install

### DIFF
--- a/src/openalea/plantscan3d/shareddata.py
+++ b/src/openalea/plantscan3d/shareddata.py
@@ -4,7 +4,7 @@ from pathlib import Path
 def get_shared_data(file, share_path="data"):
     try:
         datadir = Path(__file__).parent / share_path
-        return datadir / file
+        return str(datadir / file)
     except:
         import os
 

--- a/src/openalea/plantscan3d/ui_compiler.py
+++ b/src/openalea/plantscan3d/ui_compiler.py
@@ -34,20 +34,20 @@ def compile_rc(rcfname):
 def check_ui_generation(uifname):
     """ check if a py file should regenerated from a ui """
     pyfname = get_uifnames_from(uifname)
-    if ( os.path.exists(uifname) and 
-         not os.path.exists(pyfname) or
-         (os.access(pyfname,os.F_OK|os.W_OK) and
-         os.stat(pyfname).st_mtime < os.stat(uifname).st_mtime )) :
+    if ( os.path.exists(uifname) and
+         ( not os.path.exists(pyfname) or
+           (os.access(pyfname,os.F_OK|os.W_OK) and
+            os.stat(pyfname).st_mtime < os.stat(uifname).st_mtime ))) :
          print('Generate Ui')
          compile_ui(uifname)
 
 def check_rc_generation(rcfname):
     """ check if a py file should regenerated from a Resource file """
     pyfname = get_rcfnames_from(rcfname)
-    if (os.path.exists(rcfname) and 
-        not os.path.exists(pyfname) or
-        (os.access(pyfname,os.F_OK|os.W_OK) and
-        os.stat(pyfname).st_mtime < os.stat(rcfname).st_mtime )) :
+    if ( os.path.exists(rcfname) and
+         ( not os.path.exists(pyfname) or
+           (os.access(pyfname,os.F_OK|os.W_OK) and
+            os.stat(pyfname).st_mtime < os.stat(rcfname).st_mtime ))) :
         print('Generate Rc')
         compile_rc(rcfname)
 


### PR DESCRIPTION
Hi, here is a PR for two fixes I had to apply before being able to use the software. It works great by the way !!!

Running on Ubuntu 24.04. 

## Context

  I couldn't install plantscan3d via the standard mamba/conda path (it fails), so I fell back to a [development install from source](https://plantscan3d.readthedocs.io/en/latest/installation.html#install-from-source). Running the app then surfaced two separate crashes, both of which happen on any non-source install. This PR fixes both.

  ## Bug 1 — `ui_compiler.py`: crash on startup when `.ui`/`.rc` sources are absent

  Launching the app crashed while importing the database editor:

```python
  File ".../openalea/plantscan3d/ui_compiler.py", line 40, in check_ui_generation
      os.stat(pyfname).st_mtime < os.stat(uifname).st_mtime )) :
  FileNotFoundError: [Errno 2] No such file or directory: '.../database/database.ui'
```
**Cause:** operator precedence in `check_ui_generation` (and the identical `check_rc_generation`). Because `and` binds tighter than `or`, the condition

```python
  if ( os.path.exists(uifname) and
       not os.path.exists(pyfname) or
       (os.access(pyfname, ...) and os.stat(pyfname).st_mtime < os.stat(uifname).st_mtime )):
```
parses as (exists(ui) and not exists(py)) or (access(py) and stat(py) < stat(ui)). The second branch runs even when the .ui source is missing — and installed packages ship only the generated *_ui.py, not the .ui. os.stat(uifname) then raises FileNotFoundError.

Fix: gate the whole check on the source file existing, by parenthesizing the or clause so the mtime comparison only runs when the .ui/.rc file is present.

## Bug 2 — shareddata.py: TypeError from Qt file dialogs on first use

  Importing a point cloud (with no prior file history) crashed:
```python
  TypeError: getOpenFileName(...): argument 3 has unexpected type 'PosixPath'
  File ".../openalea/plantscan3d/main_viewer.py", line 1366, in importPoints
      fname = QFileDialog.getOpenFileName(self, "Open Points file", initialname, ...)
```
Cause: with no file history, initialname falls back to get_shared_data(...), which returned a pathlib.Path. PyQt5's QFileDialog.getOpenFileName/getSaveFileName require a str for the directory argument and reject a Path. This affects every import/open/save dialog that uses the shared-data fallback.

Fix: get_shared_data now returns str(datadir / file). This is consistent with the function's own except branch, which already returns a str (os.getcwd()), and its other callers (os.path.join, os.path.exists) accept strings fine.

## Changes

  - src/openalea/plantscan3d/ui_compiler.py — fix operator precedence in check_ui_generation and check_rc_generation.
  - src/openalea/plantscan3d/shareddata.py — return str instead of Path from get_shared_data.
